### PR TITLE
Move `i` declaration, make inputs const

### DIFF
--- a/src/inflate.c
+++ b/src/inflate.c
@@ -378,24 +378,24 @@ static int8_t deflate_static_huffman()
 	for (i = 280; i <= 287; i++) {
 		deflate_lld_lengths[i] = 8;
 	}
-	for (i = 288; i <= 288 + 29; i++) {
+	for (i = 288; i < 288 + 30; i++) {
 		deflate_lld_lengths[i] = 5;
 	}
 
 #ifdef DEFLATE_WITH_LUT
 	deflate_build_alphabet(deflate_lld_lengths, 288, deflate_bl_count_ll,
 			       deflate_next_code_ll, deflate_ll_codes);
-	deflate_build_alphabet(deflate_lld_lengths + 288, 29,
+	deflate_build_alphabet(deflate_lld_lengths + 288, 30,
 			       deflate_bl_count_d, deflate_next_code_d,
 			       deflate_d_codes);
 	return deflate_huffman(deflate_ll_codes, deflate_d_codes);
 #else
 	deflate_build_alphabet(deflate_lld_lengths, 288, deflate_bl_count_ll,
 			       deflate_next_code_ll);
-	deflate_build_alphabet(deflate_lld_lengths + 288, 29,
+	deflate_build_alphabet(deflate_lld_lengths + 288, 30,
 			       deflate_bl_count_d, deflate_next_code_d);
 	return deflate_huffman(deflate_lld_lengths, 288,
-			       deflate_lld_lengths + 288, 29);
+			       deflate_lld_lengths + 288, 30);
 #endif
 }
 

--- a/src/inflate.c
+++ b/src/inflate.c
@@ -11,8 +11,8 @@
 /*
  * The compressed (inflated) input data.
  */
-unsigned char *deflate_input_now;
-unsigned char *deflate_input_end;
+const unsigned char *deflate_input_now;
+const unsigned char *deflate_input_end;
 
 /*
  * The decompressed (deflated) output stream.
@@ -465,7 +465,7 @@ static int8_t deflate_dynamic_huffman()
 #endif
 }
 
-int16_t inflate(unsigned char *input_buf, uint16_t input_len,
+int16_t inflate(const unsigned char *input_buf, uint16_t input_len,
 		unsigned char *output_buf, uint16_t output_len)
 {
 	deflate_input_now = input_buf;
@@ -506,7 +506,7 @@ int16_t inflate(unsigned char *input_buf, uint16_t input_len,
 	}
 }
 
-int16_t inflate_zlib(unsigned char *input_buf, uint16_t input_len,
+int16_t inflate_zlib(const unsigned char *input_buf, uint16_t input_len,
 		     unsigned char *output_buf, uint16_t output_len)
 {
 	if (input_len < 4) {

--- a/src/inflate.c
+++ b/src/inflate.c
@@ -8,17 +8,25 @@
 
 #include "inflate.h"
 
+#include <stddef.h>
+
 /*
  * The compressed (inflated) input data.
  */
-const unsigned char *deflate_input_now;
-const unsigned char *deflate_input_end;
-
+static const unsigned char *deflate_input_now;
+static const unsigned char *deflate_input_end;
 /*
  * The decompressed (deflated) output stream.
  */
-unsigned char *deflate_output_now;
-unsigned char *deflate_output_end;
+static unsigned char *deflate_output_start;
+static unsigned char *deflate_output_now;
+static unsigned char *deflate_output_end;
+
+/*
+ * The dictionary input data
+ */
+static const unsigned char *dict_input;
+static const unsigned char *dict_input_end;
 
 /*
  * The current bit offset in the input stream, if any.
@@ -312,8 +320,14 @@ static int8_t deflate_huffman(uint8_t * ll_lengths, uint16_t ll_size,
 				if (deflate_output_now == deflate_output_end) {
 					return DEFLATE_ERR_OUTPUT_LENGTH;
 				}
-				deflate_output_now[0] =
-				    *(deflate_output_now - dist_val);
+				if (deflate_output_now - dist_val < deflate_output_start) {
+			        // figure out how far back to read in the dictionary
+					ptrdiff_t dist_from_end_of_dict = dist_val - (deflate_output_now - deflate_output_start);
+					deflate_output_now[0] = *(dict_input_end - dist_from_end_of_dict);
+				} else {
+					deflate_output_now[0] =
+						*(deflate_output_now - dist_val);
+				}
 				deflate_output_now++;
 			}
 		}
@@ -466,12 +480,18 @@ static int8_t deflate_dynamic_huffman()
 }
 
 int16_t inflate(const unsigned char *input_buf, uint16_t input_len,
-		unsigned char *output_buf, uint16_t output_len)
+		unsigned char *output_buf, uint16_t output_len,
+                const unsigned char *dict_buf, uint16_t dict_len)
 {
 	deflate_input_now = input_buf;
 	deflate_input_end = input_buf + input_len;
+	if (dict_buf) {
+		dict_input = dict_buf;
+		dict_input_end = dict_buf + dict_len;
+	}
 	deflate_bit_offset = 0;
 
+	deflate_output_start = output_buf;
 	deflate_output_now = output_buf;
 	deflate_output_end = output_buf + output_len;
 
@@ -506,8 +526,34 @@ int16_t inflate(const unsigned char *input_buf, uint16_t input_len,
 	}
 }
 
+// Returns 1 if Adler32(data[0:len]) == adler32[0:3], 0 otherwise
+static int16_t adler32(const unsigned char *data, const unsigned char *end, const unsigned char *adler32_val) {
+	uint16_t deflate_s1 = 1;
+	uint16_t deflate_s2 = 0;
+
+	for (; data < end; data++) {
+		deflate_s1 =
+		    ((uint32_t) deflate_s1 +
+		     (uint32_t) (*data)) % 65521;
+		deflate_s2 =
+		    ((uint32_t) deflate_s2 +
+		     (uint32_t) deflate_s1) % 65521;
+	}
+
+	if ((deflate_s2 !=
+	     (((uint16_t) adler32_val[0] << 8) | (uint16_t)
+	      adler32_val[1]))
+	    || (deflate_s1 !=
+		(((uint16_t) adler32_val[2] << 8) | (uint16_t)
+		 adler32_val[3]))) {
+		return 0;
+	}
+	return 1;
+}
+
 int16_t inflate_zlib(const unsigned char *input_buf, uint16_t input_len,
-		     unsigned char *output_buf, uint16_t output_len)
+		     unsigned char *output_buf, uint16_t output_len,
+                     const unsigned char *dict, uint16_t dict_len)
 {
 	if (input_len < 4) {
 		return DEFLATE_ERR_INPUT_LENGTH;
@@ -519,8 +565,17 @@ int16_t inflate_zlib(const unsigned char *input_buf, uint16_t input_len,
 		return DEFLATE_ERR_METHOD;
 	}
 
+	uint32_t data_offset = 2;
 	if (zlib_flags & 0x20) {
-		return DEFLATE_ERR_FDICT;
+		if (!dict || dict_len == 0) {
+			return DEFLATE_ERR_FDICT;
+		}
+#ifdef DEFLATE_CHECKSUM
+		if (!adler32(dict, dict + dict_len, input_buf + 2)) {
+			return DEFLATE_ERR_CHECKSUM - 10;
+		}
+#endif
+		data_offset += 4;
 	}
 
 	if ((((uint16_t) input_buf[0] << 8) | input_buf[1]) % 31) {
@@ -528,38 +583,20 @@ int16_t inflate_zlib(const unsigned char *input_buf, uint16_t input_len,
 	}
 
 	int16_t ret =
-	    inflate(input_buf + 2, input_len - 2, output_buf, output_len);
+	    inflate(input_buf + data_offset, input_len - data_offset,
+			    output_buf, output_len, dict, dict_len);
 
 #ifdef DEFLATE_CHECKSUM
 	if (ret >= 0) {
-		uint16_t deflate_s1 = 1;
-		uint16_t deflate_s2 = 0;
-
-		deflate_output_end = deflate_output_now;
-		for (deflate_output_now = output_buf;
-		     deflate_output_now < deflate_output_end;
-		     deflate_output_now++) {
-			deflate_s1 =
-			    ((uint32_t) deflate_s1 +
-			     (uint32_t) (*deflate_output_now)) % 65521;
-			deflate_s2 =
-			    ((uint32_t) deflate_s2 +
-			     (uint32_t) deflate_s1) % 65521;
-		}
-
 		if (deflate_bit_offset) {
 			deflate_input_now++;
 		}
-
-		if ((deflate_s2 !=
-		     (((uint16_t) deflate_input_now[0] << 8) | (uint16_t)
-		      deflate_input_now[1]))
-		    || (deflate_s1 !=
-			(((uint16_t) deflate_input_now[2] << 8) | (uint16_t)
-			 deflate_input_now[3]))) {
+		if (!adler32(output_buf, deflate_output_now, deflate_input_now)) {
 			return DEFLATE_ERR_CHECKSUM;
 		}
 	}
+#else
+	(void) adler32;
 #endif
 
 	return ret;

--- a/src/inflate.c
+++ b/src/inflate.c
@@ -387,16 +387,15 @@ static int8_t deflate_static_huffman()
 
 static int8_t deflate_dynamic_huffman()
 {
-	uint8_t i;
 	uint16_t hlit = 257 + deflate_get_bits(5);
 	uint8_t hdist = 1 + deflate_get_bits(5);
 	uint8_t hclen = 4 + deflate_get_bits(4);
 
-	for (i = 0; i < hclen; i++) {
+	for (uint8_t i = 0; i < hclen; i++) {
 		deflate_hc_lengths[deflate_hclen_index[i]] =
 		    deflate_get_bits(3);
 	}
-	for (i = hclen; i < sizeof(deflate_hc_lengths); i++) {
+	for (uint8_t i = hclen; i < sizeof(deflate_hc_lengths); i++) {
 		deflate_hc_lengths[deflate_hclen_index[i]] = 0;
 	}
 

--- a/src/inflate.h
+++ b/src/inflate.h
@@ -19,6 +19,8 @@
 #define DEFLATE_ERR_HUFFMAN (-9)
 
 int16_t inflate(const unsigned char *input_buf, uint16_t input_len,
-		unsigned char *output_buf, uint16_t output_len);
+		unsigned char *output_buf, uint16_t output_len,
+                const unsigned char *dict_buf, uint16_t dict_len);
 int16_t inflate_zlib(const unsigned char *input_buf, uint16_t input_len,
-		     unsigned char *output_buf, uint16_t output_len);
+		     unsigned char *output_buf, uint16_t output_len,
+                     const unsigned char *dict_buf, uint16_t dict_len);

--- a/src/inflate.h
+++ b/src/inflate.h
@@ -18,7 +18,7 @@
 #define DEFLATE_ERR_NLEN (-8)
 #define DEFLATE_ERR_HUFFMAN (-9)
 
-int16_t inflate(unsigned char *input_buf, uint16_t input_len,
+int16_t inflate(const unsigned char *input_buf, uint16_t input_len,
 		unsigned char *output_buf, uint16_t output_len);
-int16_t inflate_zlib(unsigned char *input_buf, uint16_t input_len,
+int16_t inflate_zlib(const unsigned char *input_buf, uint16_t input_len,
 		     unsigned char *output_buf, uint16_t output_len);

--- a/test/deflate
+++ b/test/deflate
@@ -7,12 +7,23 @@ level = -1
 if len(sys.argv) > 2:
     level = int(sys.argv[2])
 
-try:
-	with open(sys.argv[1], "rb") as f:
-		input_data = f.read()
-except FileNotFoundError:
-	input_data = sys.argv[1].encode("utf-8")
+use_dict = False
+if len(sys.argv) > 3:
+    use_dict = bool(int(sys.argv[3]))
 
-output = zlib.compress(input_data, level=level)
+try:
+    with open(sys.argv[1], "rb") as f:
+        input_data = f.read()
+except FileNotFoundError:
+    input_data = sys.argv[1].encode("utf-8")
+
+preset_dict = None
+if use_dict:
+    preset_dict = input_data[:len(input_data) // 2]
+    compressor = zlib.compressobj(level=level, zdict=preset_dict)
+    output = compressor.compress(input_data)
+    output += compressor.flush()
+else:
+    output = zlib.compress(input_data, level=level)
 
 sys.stdout.buffer.write(output)

--- a/test/inflate-app.c
+++ b/test/inflate-app.c
@@ -3,9 +3,19 @@
 
 #include "inflate.h"
 
+static int read_til_eof(unsigned char* into, size_t len, FILE* f) {
+  int bytes_read = 0;
+  while (!feof(f) && !ferror(f)) {
+    bytes_read += fread(into, 1, len - bytes_read, f);
+  }
+  if (ferror(f)) {
+    bytes_read = 0;
+  }
+  return bytes_read;
+}
+
 int main(int argc, char** argv)
 {
-
 	// 16 MB
 	unsigned char *inbuf = (unsigned char*)malloc(4096 * 4096);
 	unsigned char *outbuf = (unsigned char*)malloc(4096 * 4096);
@@ -22,7 +32,7 @@ int main(int argc, char** argv)
           if (!dict_buf || !dict_file) {
             return 1;
           }
-          dict_size = fread(dict_buf, 1, 4096 * 4096, dict_file);
+          dict_size = read_til_eof(dict_buf, 4096 * 4096, dict_file);
           if (dict_size <= 0) {
             return 1;
           }
@@ -30,7 +40,7 @@ int main(int argc, char** argv)
           fclose(dict_file);
         }
 
-	size_t in_size = fread(inbuf, 1, 4096 * 4096, stdin);
+	size_t in_size = read_til_eof(inbuf, 4096 * 4096, stdin);
 
 	if (in_size == 0) {
 		return 1;

--- a/test/inflate-app.c
+++ b/test/inflate-app.c
@@ -3,18 +3,32 @@
 
 #include "inflate.h"
 
-unsigned char *inbuf;
-unsigned char *outbuf;
-
-int main(void)
+int main(int argc, char** argv)
 {
+
 	// 16 MB
-	inbuf = (unsigned char*)malloc(4096 * 4096);
-	outbuf = (unsigned char*)malloc(4096 * 4096);
+	unsigned char *inbuf = (unsigned char*)malloc(4096 * 4096);
+	unsigned char *outbuf = (unsigned char*)malloc(4096 * 4096);
 
 	if (inbuf == NULL || outbuf == NULL) {
 		return 1;
 	}
+
+        size_t dict_size = 0;
+        unsigned char *dict_buf = NULL;
+        if (argc > 1) {
+          dict_buf = (unsigned char*)malloc(4096 * 4096);
+          FILE* dict_file = fopen(argv[1], "rb");
+          if (!dict_buf || !dict_file) {
+            return 1;
+          }
+          dict_size = fread(dict_buf, 1, 4096 * 4096, dict_file);
+          if (dict_size <= 0) {
+            return 1;
+          }
+          dict_size /= 2;
+          fclose(dict_file);
+        }
 
 	size_t in_size = fread(inbuf, 1, 4096 * 4096, stdin);
 
@@ -22,7 +36,7 @@ int main(void)
 		return 1;
 	}
 
-	int16_t out_size = inflate_zlib(inbuf, in_size, outbuf, 65535);
+	int16_t out_size = inflate_zlib(inbuf, in_size, outbuf, 65535, dict_buf, dict_size);
 
 	if (out_size < 0) {
 		return -out_size;

--- a/test/test.sh
+++ b/test/test.sh
@@ -5,10 +5,10 @@ set -eu
 cd "$(dirname "$0")"
 
 run_tests() {
-	for file in $(find .. -type f -size -32760c); do
-		if ! ./deflate $file | ./inflate > tmp; then
+	for file in $(find .. -type f -size -32760c -not -name tmp); do
+                if ! ./deflate $file -1 $1 | ./inflate $file > tmp; then
 			echo "inflate error at $file"
-			./deflate $file | ./inflate > tmp
+                        ./deflate $file -1 $1 | ./inflate $file > tmp
 		fi
 		diff $file tmp
 	done
@@ -17,16 +17,20 @@ run_tests() {
 for std in c++11 c++20 c99 c11; do
 
 	"./compile-${std}.sh"
-	run_tests
+	run_tests 0
 
 	"./compile-${std}.sh" -DDEFLATE_CHECKSUM
-	run_tests
+	run_tests 0
 
 	"./compile-${std}.sh" -DDEFLATE_WITH_LUT
-	run_tests
+	run_tests 0
 
 	"./compile-${std}.sh" -DDEFLATE_CHECKSUM -DDEFLATE_WITH_LUT
-	run_tests
+	run_tests 0
+
+	"./compile-${std}.sh" -DDEFLATE_CHECKSUM -DDEFLATE_WITH_LUT
+	run_tests 1
+
 
 done
 


### PR DESCRIPTION
 - Move `i` declaration to get GCC to not complain with `-Wshadow`
 - Make inputs const